### PR TITLE
feat: Enhance two-sided conversation analysis

### DIFF
--- a/frontend/src/pages/MessageAnalyzer.js
+++ b/frontend/src/pages/MessageAnalyzer.js
@@ -81,7 +81,9 @@ const MessageAnalyzer = () => {
                     <div className="w-3 h-3 mt-1 rounded-full mr-2 bg-red-500"></div>
                     <div>
                       <p className="text-sm font-medium text-gray-800">
-                        {flag.type}
+                        {flag.participant 
+                          ? `${flag.type} (${flag.participant.charAt(0).toUpperCase() + flag.participant.slice(1)} Message)` 
+                          : flag.type}
                       </p>
                       <p className="text-sm text-gray-600">
                         {flag.description}


### PR DESCRIPTION
This commit introduces improvements to the message analysis feature to better support two-sided conversations and attribute red flags to the specific participant (their message vs. your response).

Changes include:

Backend (`server.py`):
- Enhanced the simulated analysis logic in `analyze_message` to differentiate between "Their message" and "Your response" when detecting flags.
- Modified the `Flag` Pydantic model to include an optional `participant` field (`their` or `your`).
- Updated the API response to populate this `participant` field for each detected flag.

Frontend (`MessageAnalyzer.js`):
- Updated the `renderAnalysisCard` function to display the flag attribution (e.g., "Gaslighting (Their Message)") if the `participant` field is present in the flag data.

I considered conceptual tests as part of this change, outlining the necessary unit tests for backend logic and frontend display to verify these new features.